### PR TITLE
Add Podscan crawlers to rss-ua.json

### DIFF
--- a/src/rss-ua.json
+++ b/src/rss-ua.json
@@ -1548,6 +1548,15 @@
         "reportssubs": "0"
     },
     {
+        "pattern": "PodscanBot\/",
+        "name": "Podscan",
+        "slug": "podscan.fm",
+        "url": "https:\/\/podscan.fm",
+        "acceptsaac": "0",
+        "acceptsopus": "0",
+        "reportssubs": "0"
+    },
+    {
         "pattern": "Podscribe",
         "name": "Podscribe",
         "slug": "app.podscribe",


### PR DESCRIPTION
The crawlers of Podscan.fm use `PodscanBot/1.1.0 Ubuntu/22.04 (Linux) +https://podscan.fm` as their user agent at all times.